### PR TITLE
Fixes syntax error in setup.js

### DIFF
--- a/src/boot/setup.js
+++ b/src/boot/setup.js
@@ -5,7 +5,7 @@ import App from "../App";
 import configureStore from "./configureStore";
 
 export default class Setup extends Component {
-  state: {
+  state = {
     store: Object,
     isLoading: boolean,
     isReady: boolean

--- a/src/boot/setup.js
+++ b/src/boot/setup.js
@@ -5,11 +5,7 @@ import App from "../App";
 import configureStore from "./configureStore";
 
 export default class Setup extends Component {
-  state = {
-    store: Object,
-    isLoading: boolean,
-    isReady: boolean
-  };
+
   constructor() {
     super();
     this.state = {


### PR DESCRIPTION
Updates state to `state = ` instead of `state: `